### PR TITLE
MO2 2.5.1rc2 and instructions

### DIFF
--- a/mo2.html
+++ b/mo2.html
@@ -173,46 +173,49 @@
 
             <!-- Installing MO2 -->
             <p>
-                <a href="#installingMo2">
-                    <h2 id="installingMo2">Installing Mod Organizer 2</h2>
+                <a href="#installation">
+                    <h2 id="installation">Installing Mod Organizer 2</h2>
                 </a>
             </p>
             <ol>
-                <li>Download <strong>Mod Organizer 2</strong> from <a href="https://mega.nz/file/EmxzyLLb#0y6vxJ6iy0QRWNn2wTXV56CMkhyfAF8MunZ_w1RfeKE" target="_blank">here</a>.</li>
-                <li>Once the download has finished, extract the archive anywhere <u>outside</u> of the default Windows folders (like <code>Program Files x86</code>) and <u>outside</u> of the game's <strong>Root</strong> folder.
-                    <br>Example install path: <code>C:\Games\MO2\DragonbornsFate</code>
+                <li>Download <strong>Mod Organizer 2</strong> from <a href="https://github.com/ModOrganizer2/modorganizer/releases/download/v2.5.1rc2/Mod.Organizer-2.5.1rc2.7z" target="_blank">here</a>.</li>
+                <li>Once the download has finished, right click the file and open its <strong>Properties</strong>.</li>
+                <li>In the properties window, tick the <strong>Unblock</strong> checkbox under <strong>Security</strong> section.</li>
+                <blockquote>
+                    This operation is required because Windows can block MO2 files from loading.
+                    <br>
+                    If you used the installer, this action is not needed as it handles it automatically.
+                </blockquote>
+                <li>Extract the archive anywhere <u>outside</u> of the default Windows folders (like <code>Program Files x86</code>) and <u>outside</u> of the game's <strong>Root</strong> folder.
+                    <br>
+                    Example install path: <code>C:\Modding\MO2\DragonborsFate</code>
                 </li>
+                <blockquote>It's discouraged to store MO2 on Desktop or Documents if you use OneDrive or similar cloud providers, due to potential issues and degraded performance.</blockquote>
             </ol>
 
             <!-- MO2 -->
             <p>
-                <a href="#configMo2">
-                    <h2 id="configMo2">Configuring Mod Organizer 2</h2>
+                <a href="#configuration">
+                    <h2 id="configuration">Configuring Mod Organizer 2</h2>
                 </a>
             </p>
 
-            <!-- MO2 Setup -->
-            <p>
-                <a href="#mo2Setup">
-                    <h3 id="mo2Setup">MO2 Setup</h3>
-                </a>
-            </p>
             <ol>
                 <li>Run <strong>ModOrganizer.exe</strong> inside the Mod Organizer 2 folder you extracted before.</li>
                 <li>You will be prompted with a pop-up called <strong>Creating an instance</strong>, in which you should just select <strong>Next</strong>.</li>
-                <li>On the next page, select <strong>Create a portable instance</strong>.</li>
+                <li>Create a <strong>portable instance</strong>.</li>
                 <img src="./img/mo2 portable instance.webp" alt="Portable instance">
-                <li>On the next page, select <strong>Skyrim Special Edition</strong>.</li>
-                <li>On the next page, keep the <strong>Location</strong> file path default.</li>
+                <li>Select <strong>Skyrim Special Edition</strong>.</li>
+                <li>Select the store where you bought the game.</li>
+                <li>Enable both <strong>profile-specific options.</strong></li>
+                <li>Keep the default <strong>Location</strong> file path.</li>
             </ol>
             <blockquote>If you have MO2 installed on an SSD or a HDD with little space, you can check the <strong>Show advanced options</strong> box and change the <strong>Downloads</strong> file path to a different drive with more space. This will not effect download/game performance, and the downloads can be deleted after the mods have been installed.</blockquote>
             <ol start="6">
                 <li>On the last page, select <strong>Finish</strong>.</li>
-                <li>MO2 will launch and prompt you with <strong>Show tutorial?</strong>, this is recommended if you never used the tool before.</li>
-                <li>From the pop-up called <strong>Register?</strong>, select <strong>Yes</strong>.</li>
-                <ul>
-                    <li>This pop-up will not show up if you have already registered a different instance of MO2.</li>
-                </ul>
+                <li>MO2 will launch and prompt you with <strong>Category Setup</strong>, select <strong>Do Nothing</strong>.</li>
+                <li>If you see a pop-up called <strong>INI file is read-only</strong>, select <strong>Remember my choice</strong> from the drop-down at the bottom then click <strong>Clear the read-only flag</strong>.</li>
+                <li>If you see a pop-up called <strong>Register?</strong>, select <strong>Yes</strong>.</li>
             </ol>
 
             <!-- Exceptions -->
@@ -229,7 +232,14 @@
                 <li>Add a <b>Folder</b> exclusion and point it to the folder <strong>Mod Organizer 2</strong> is in.</li>
                 <li>Add another exclusion for your <strong>game folder</strong> (the game's root folder, not documents).</li>
             </ol>
-            <blockquote>If you are using a third-party antivirus, you will need to find the exceptions menu and add those 2 folders mentioned previously.</blockquote>
+            <blockquote>
+                This operation is required because Windows can block MO2 and mod files from loading due to how MO2's virtualized filesystem works.
+                <br>
+                If you used the installer, this action is not needed as it handles it automatically.
+                <br>
+                <br>
+                If you are using a third-party antivirus, you will need to find the exceptions menu and add those 2 folders mentioned previously.
+            </blockquote>
 
             <!-- Settings -->
             <p>
@@ -251,24 +261,12 @@
                 <li>Allow MO2 to restart if it asks.</li>
             </ol>
 
-            <!-- Profiles -->
+            <!-- INI Configuration -->
             <p>
-                <a href="#profiles">
-                    <h2 id="profiles">Creating Profiles</h2>
+                <a href="#iniConfig">
+                    <h2 id="iniConfig">Configuring INI Files</h2>
                 </a>
             </p>
-            Mod Organizer 2's "Profiles" feature allows for easy switching between different modlist and load order configurations. In this step, we will create a profile for the guide while keeping a strictly-vanilla profile for testing/de-bugging. Profiles can be selected via the drop-down menu above the left pane.
-            <ol>
-                <li>Select the <img src="./img/mo2 profiles.webp" alt="MO2 profiles"> button at the top of MO2 to open the profiles menu.</li>
-                <li>Select the <strong>Default</strong> profile, then select <strong>Copy</strong>.</li>
-                <li>Name the new profile <strong>A Dragonborn's Fate</strong>.</li>
-                <li>Select the <strong>A Dragonborn's Fate</strong> profile and make sure <strong>Use profile-specific Game INI Files</strong> is <strong>Disabled</strong> at the bottom.</li>
-            </ol>
-            <blockquote>You may get a pop-up called <strong>INI file is read-only</strong> when attempting to make/select a new profile. If so then select <strong>Remember my choice</strong> from the drop-down at the bottom then click <strong>Clear the read-only flag</strong>.</blockquote>
-            <ol start="5">
-                <li>Exit out of the profiles menu and select the <strong>A Dragonborn's Fate</strong> profile from the drop-down above the left pane.</li>
-                <img src="./img/mo2 profile select.webp" alt="Profile selection">
-            </ol>
 
             <!-- BethINI -->
             <p>
@@ -305,8 +303,8 @@
 
             <!-- Instructions -->
             <p>
-                <a href="#installationInstructions">
-                    <h2 id="installationInstructions">Mod Installation Instructions</h2>
+                <a href="#instructions">
+                    <h2 id="instructions">Mod Installation Instructions</h2>
                 </a>
             </p>
             <blockquote>
@@ -359,15 +357,12 @@
     <div id="sidenavRight">
         <ul>
             <li>
-                <a href="#installingMo2">Installation</a>
+                <a href="#installation">Installation</a>
             </li>
             <li>
-                <a href="#configMo2">Configuration</a>
+                <a href="#configuration">MO2 Configuration</a>
             </li>
             <ul>
-                <li>
-                    <a href="#mo2Setup">MO2 Setup</a>
-                </li>
                 <li>
                     <a href="#exceptions">Exceptions</a>
                 </li>
@@ -376,16 +371,18 @@
                 </li>
             </ul>
             <li>
-                <a href="#profiles">Profiles</a>
+                <a href="#iniConfig">INI Configuration</a>
             </li>
+            <ul>
+                <li>
+                    <a href="#bethIni">BethINI</a>
+                </li>
+                <li>
+                    <a href="#customIni">Custom INI</a>
+                </li>
+            </ul>
             <li>
-                <a href="#bethIni">BethINI</a>
-            </li>
-            <li>
-                <a href="#customIni">Custom INI</a>
-            </li>
-            <li>
-                <a href="#installationInstructions">Installation Instructions</a>
+                <a href="#instructions">Installation Instructions</a>
             </li>
         </ul>
     </div>

--- a/mo2.html
+++ b/mo2.html
@@ -188,7 +188,7 @@
                 </blockquote>
                 <li>Extract the archive anywhere <u>outside</u> of the default Windows folders (like <code>Program Files x86</code>) and <u>outside</u> of the game's <strong>Root</strong> folder.
                     <br>
-                    Example install path: <code>C:\Modding\MO2\DragonborsFate</code>
+                    Example install path: <code>C:\Modding\MO2\DragonbornsFate</code>
                 </li>
                 <blockquote>It's discouraged to store MO2 on Desktop or Documents if you use OneDrive or similar cloud providers, due to potential issues and degraded performance.</blockquote>
             </ol>
@@ -207,11 +207,11 @@
                 <img src="./img/mo2 portable instance.webp" alt="Portable instance">
                 <li>Select <strong>Skyrim Special Edition</strong>.</li>
                 <li>Select the store where you bought the game.</li>
-                <li>Enable both <strong>profile-specific options.</strong></li>
+                <li>Disable both <strong>profile-specific options.</strong></li>
                 <li>Keep the default <strong>Location</strong> file path.</li>
             </ol>
             <blockquote>If you have MO2 installed on an SSD or a HDD with little space, you can check the <strong>Show advanced options</strong> box and change the <strong>Downloads</strong> file path to a different drive with more space. This will not effect download/game performance, and the downloads can be deleted after the mods have been installed.</blockquote>
-            <ol start="6">
+            <ol start="8">
                 <li>On the last page, select <strong>Finish</strong>.</li>
                 <li>MO2 will launch and prompt you with <strong>Category Setup</strong>, select <strong>Do Nothing</strong>.</li>
                 <li>If you see a pop-up called <strong>INI file is read-only</strong>, select <strong>Remember my choice</strong> from the drop-down at the bottom then click <strong>Clear the read-only flag</strong>.</li>


### PR DESCRIPTION
- Changes MO2 download to 2.5.1rc2 and updates instructions to match
- Removes profiles section for parity with other guides