### PR TITLE
Update changelog for Skylighting and Terrain Blending versions

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -279,9 +279,9 @@
                                 <li>Community Shaders (1.7.3)</li>
                                 <li>Wetness Effects - Community Shaders (3.1.0)</li>
                                 <li>Screen Space Global Illumination (SSGI) - Community Shaders (4.2.0)</li>
-                                <li>Skylighting - Community Shaders (1.2.3)</li>
+                                <li>Skylighting - Community Shaders (1.4.0)</li>
                                 <li>Cloud Shadows - Community Shaders (1.4.0)</li>
-                                <li>Terrain Blending - Community Shaders (1.1.0)</li>
+                                <li>Terrain Blending - Community Shaders (1.2.0)</li>
                                 <li>DynDOLOD Resources SE 3 (Alpha-59)</li>
                                 <li>DynDOLOD DLL NG (Alpha-41)</li>
                                 <li>DBF Pre-Generated Object LOD</li>


### PR DESCRIPTION
The version in the change log does not reflect the updated version. 

Community Shaders updates:

* Updated `Skylighting - Community Shaders` from version 1.2.3 to 1.4.0.
* Updated `Terrain Blending - Community Shaders` from version 1.1.0 to 1.2.0.